### PR TITLE
new enableRegisty and disableRegistry functions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,11 @@ History
 1.0.1
 -----
 
-- wrong information in README.rst corrected. 
+- Added enableRegistry and disableRegistry in order to make event subscribers
+simpler. Now you can enable a local Registry in a simple folder and not only on collective.lineage.content.ChildFolder. See: tests.TestLineageRegistry
+[gborelli]
+
+- wrong information in README.rst corrected.
   [jensens]
 
 1.0

--- a/src/lineage/registry/subscribers.py
+++ b/src/lineage/registry/subscribers.py
@@ -1,29 +1,19 @@
-from zope.component import (
-    adapter,
-    getSiteManager,
-)
-from plone.registry.interfaces import IRegistry
+from zope.component import adapter
+
 from collective.lineage.interfaces import (
     IChildSiteCreatedEvent,
     IChildSiteRemovedEvent,
 )
-from .proxy import (
-    REGISTRY_NAME,
-    LineageRegistry,
-)
+
+from .utils import enableRegistry
+from .utils import disableRegistry
+
 
 @adapter(IChildSiteCreatedEvent)
 def enableChildRegistry(event):
-    child = event.object
-    sm = getSiteManager(context=child)    
-    if REGISTRY_NAME not in child.objectIds():
-        child[REGISTRY_NAME] = LineageRegistry(REGISTRY_NAME).__of__(child)
-    sm.registerUtility(component=child[REGISTRY_NAME], provided=IRegistry) 
-    
+    enableRegistry(event.object)
+
+
 @adapter(IChildSiteRemovedEvent)
 def disableChildRegistry(event):
-    if REGISTRY_NAME not in child.objectIds():
-        return
-    # we keep the registry here (intentionally)
-    sm = getSiteManager(context=child)
-    sm.unregisterUtility(component=child[REGISTRY_NAME], provided=IRegistry)
+    disableRegistry(event.object)

--- a/src/lineage/registry/tests.py
+++ b/src/lineage/registry/tests.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2 as unittest
 import doctest
 import pprint
 from interlude import interact
@@ -15,20 +15,76 @@ TESTFILES = [
 optionflags = doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS
 optionflags |= doctest.REPORT_ONLY_FIRST_FAILURE
 
+from zope.component import getUtility
+from zope.component.hooks import setSite
+from zope.component.interfaces import ISite
+
+from five.localsitemanager import make_objectmanager_site
+
+from Products.CMFCore.utils import getToolByName
+
+from plone.registry.interfaces import IRegistry
+
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import setRoles
+
+from plone.app.registry.registry import Registry
+
+from .proxy import LineageRegistry
+from .proxy import REGISTRY_NAME
+
+from .utils import enableRegistry
+from .utils import disableRegistry
+
+
+class TestLineageRegistry(unittest.TestCase):
+    layer = LINEAGEREGISTRY_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def test_registry_assignment(self):
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        self.oid = self.portal.invokeFactory('Folder', 'folder')
+        setRoles(self.portal, TEST_USER_ID, ['Member'])
+
+        folder = self.portal[self.oid]
+        registry = getUtility(IRegistry)
+
+        if not ISite.providedBy(folder):
+            make_objectmanager_site(folder)
+
+        setSite(folder)
+
+        pc = getToolByName(folder, 'portal_catalog')
+        pc.reindexObject(folder, idxs=['object_provides'])
+
+        enableRegistry(folder)
+        self.assertIn(REGISTRY_NAME, folder.objectIds())
+
+        registry = getUtility(IRegistry)
+        self.assertTrue(isinstance(registry, LineageRegistry))
+
+        disableRegistry(folder)
+        registry = getUtility(IRegistry)
+        self.assertTrue(isinstance(registry, Registry))
+
+
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTests([
-            layered(
-                doctest.DocFileSuite(
-                    docfile,
-                    globs={'interact': interact,
-                           'pprint': pprint.pprint,
-                           'z2': z2,
-                           },
-                    optionflags=optionflags,
-                    ),
-                layer=layer,
-                )
-            for docfile, layer in TESTFILES
-            ])
+        layered(
+            doctest.DocFileSuite(
+                docfile,
+                globs={'interact': interact,
+                       'pprint': pprint.pprint,
+                       'z2': z2,
+                       },
+                optionflags=optionflags,
+            ),
+            layer=layer,
+        )
+        for docfile, layer in TESTFILES
+    ])
+    suite.addTest(unittest.makeSuite(TestLineageRegistry))
     return suite

--- a/src/lineage/registry/utils.py
+++ b/src/lineage/registry/utils.py
@@ -1,0 +1,20 @@
+from zope.component import getSiteManager
+from plone.registry.interfaces import IRegistry
+
+from .proxy import REGISTRY_NAME
+from .proxy import LineageRegistry
+
+
+def enableRegistry(child):
+    sm = getSiteManager(context=child)
+    if REGISTRY_NAME not in child.objectIds():
+        child[REGISTRY_NAME] = LineageRegistry(REGISTRY_NAME).__of__(child)
+    sm.registerUtility(component=child[REGISTRY_NAME], provided=IRegistry)
+
+
+def disableRegistry(child):
+    if REGISTRY_NAME not in child.objectIds():
+        return
+    # we keep the registry here (intentionally)
+    sm = getSiteManager(context=child)
+    sm.unregisterUtility(component=child[REGISTRY_NAME], provided=IRegistry)


### PR DESCRIPTION
I've created a module utils that contains two functions moved out from the event subscribers.
In this way anybody can use these functions in custom code without having to fire the events
